### PR TITLE
Send cookies for auth

### DIFF
--- a/adapters/handler/auth.go
+++ b/adapters/handler/auth.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"server/core/domain"
 	"server/core/ports"
+	"time"
 )
 
 type AuthHandler struct {
@@ -56,6 +57,16 @@ func (h *AuthHandler) Register(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
+	cookie := new(http.Cookie)
+	cookie.Name = "jwt"
+	cookie.Value = token.Jwt
+	cookie.Expires = time.Now().Add(24 * 7 * time.Hour)
+	cookie.HttpOnly = true
+	cookie.Path = "/"
+	cookie.SameSite = http.SameSiteLaxMode
+	cookie.Secure = true
+	ctx.SetCookie(cookie)
+
 	return ctx.JSON(http.StatusOK, token)
 }
 
@@ -73,6 +84,17 @@ func (h *AuthHandler) Login(ctx echo.Context) error {
 	if err != nil {
 		return ctx.JSON(http.StatusBadRequest, err.Error())
 	}
+
+	cookie := new(http.Cookie)
+	cookie.Name = "jwt"
+	cookie.Value = token.Jwt
+	cookie.Expires = time.Now().Add(24 * 7 * time.Hour)
+	cookie.HttpOnly = true
+	cookie.Path = "/"
+	cookie.SameSite = http.SameSiteLaxMode
+	cookie.Secure = true
+
+	ctx.SetCookie(cookie)
 
 	return ctx.JSON(http.StatusOK, token)
 }

--- a/adapters/handler/auth.go
+++ b/adapters/handler/auth.go
@@ -57,14 +57,15 @@ func (h *AuthHandler) Register(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	cookie := new(http.Cookie)
-	cookie.Name = "jwt"
-	cookie.Value = token.Jwt
-	cookie.Expires = time.Now().Add(24 * 7 * time.Hour)
-	cookie.HttpOnly = true
-	cookie.Path = "/"
-	cookie.SameSite = http.SameSiteLaxMode
-	cookie.Secure = true
+	cookie := &http.Cookie{
+		Name:     "jwt",
+		Value:    token.Jwt,
+		Path:     "/",
+		Expires:  time.Now().Add(24 * 7 * time.Hour),
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
 	ctx.SetCookie(cookie)
 
 	return ctx.JSON(http.StatusOK, token)
@@ -85,15 +86,15 @@ func (h *AuthHandler) Login(ctx echo.Context) error {
 		return ctx.JSON(http.StatusBadRequest, err.Error())
 	}
 
-	cookie := new(http.Cookie)
-	cookie.Name = "jwt"
-	cookie.Value = token.Jwt
-	cookie.Expires = time.Now().Add(24 * 7 * time.Hour)
-	cookie.HttpOnly = true
-	cookie.Path = "/"
-	cookie.SameSite = http.SameSiteLaxMode
-	cookie.Secure = true
-
+	cookie := &http.Cookie{
+		Name:     "jwt",
+		Value:    token.Jwt,
+		Path:     "/",
+		Expires:  time.Now().Add(24 * 7 * time.Hour),
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
 	ctx.SetCookie(cookie)
 
 	return ctx.JSON(http.StatusOK, token)

--- a/adapters/handler/user.go
+++ b/adapters/handler/user.go
@@ -66,7 +66,7 @@ func (h *UserHandler) GetUser(ctx echo.Context) error {
 // @Tags         users
 // @Produce      json
 // @Success      200  {array}   []domain.GetUser
-// @Failure      500  {object}  error "Shouldn't happen, but will if something fails"
+// @Failure      500  {object}  error "Shouldn't happen, but will if something goes really wrong"
 // @Router       /api/v1/users [GET]
 func (h *UserHandler) GetUsers(ctx echo.Context) error {
 	users, err := h.serviceUser.GetUsers(ctx.Request().Context())

--- a/tools/echo/echo.go
+++ b/tools/echo/echo.go
@@ -13,7 +13,11 @@ func GetEchoInstance() *echo.Echo {
 	}
 
 	echoInstance = echo.New()
-	echoInstance.Use(middleware.CORS())
+	echoInstance.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+		AllowOrigins:                             []string{"http://localhost:5173"},
+		AllowCredentials:                         true,
+		UnsafeWildcardOriginWithAllowCredentials: false,
+	}))
 
 	InitializeValidator(echoInstance)
 


### PR DESCRIPTION
Currently explicitly creating the cookies, might need a token creation port, but that'll be apparent in the future.