### PR TITLE
Add: Access and Refresh cookies

### DIFF
--- a/adapters/handler/auth.go
+++ b/adapters/handler/auth.go
@@ -29,6 +29,7 @@ func GetAuthHandler(serviceUser ports.ServiceUser) *AuthHandler {
 func (h *AuthHandler) RegisterRoutes(e *echo.Group) {
 	e.POST("/auth/register", h.Register)
 	e.POST("/auth/login", h.Login)
+	e.POST("/auth/logout", h.Logout)
 }
 
 // Register godoc
@@ -98,4 +99,19 @@ func (h *AuthHandler) Login(ctx echo.Context) error {
 	ctx.SetCookie(cookie)
 
 	return ctx.JSON(http.StatusOK, token)
+}
+
+func (h *AuthHandler) Logout(ctx echo.Context) error {
+	cookie := &http.Cookie{
+		Name:     "jwt",
+		Value:    "",
+		Path:     "/",
+		Expires:  time.Now(),
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
+	ctx.SetCookie(cookie)
+
+	return ctx.NoContent(http.StatusOK)
 }

--- a/adapters/handler/auth.go
+++ b/adapters/handler/auth.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"server/core/domain"
 	"server/core/ports"
+	"strconv"
 	"time"
 )
 
@@ -30,6 +31,7 @@ func (h *AuthHandler) RegisterRoutes(e *echo.Group) {
 	e.POST("/auth/register", h.Register)
 	e.POST("/auth/login", h.Login)
 	e.POST("/auth/logout", h.Logout)
+	e.POST("/auth/session", h.UpdateSession)
 }
 
 // Register godoc
@@ -58,18 +60,30 @@ func (h *AuthHandler) Register(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	cookie := &http.Cookie{
-		Name:     "jwt",
-		Value:    token.Jwt,
-		Path:     "/",
-		Expires:  time.Now().Add(24 * 7 * time.Hour),
+	newRefreshCookie := &http.Cookie{
+		Name:     "refresh",
+		Value:    token.RefreshToken,
+		Path:     "/api/v1/auth/session",
+		Expires:  time.Now().Add(time.Hour * 24 * 7),
 		Secure:   true,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 	}
-	ctx.SetCookie(cookie)
 
-	return ctx.JSON(http.StatusOK, token)
+	newAccessToken := &http.Cookie{
+		Name:     "access_token",
+		Value:    token.Jwt,
+		Path:     "/",
+		Expires:  time.Now().Add(time.Minute * 30),
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
+
+	ctx.SetCookie(newRefreshCookie)
+	ctx.SetCookie(newAccessToken)
+
+	return ctx.NoContent(http.StatusOK)
 }
 
 func (h *AuthHandler) Login(ctx echo.Context) error {
@@ -87,23 +101,56 @@ func (h *AuthHandler) Login(ctx echo.Context) error {
 		return ctx.JSON(http.StatusBadRequest, err.Error())
 	}
 
-	cookie := &http.Cookie{
-		Name:     "jwt",
-		Value:    token.Jwt,
-		Path:     "/",
-		Expires:  time.Now().Add(24 * 7 * time.Hour),
+	newRefreshCookie := &http.Cookie{
+		Name:     "refresh",
+		Value:    token.RefreshToken,
+		Path:     "/api/v1/auth/session",
+		Expires:  time.Now().Add(time.Hour * 24 * 7),
 		Secure:   true,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 	}
-	ctx.SetCookie(cookie)
 
-	return ctx.JSON(http.StatusOK, token)
+	newAccessToken := &http.Cookie{
+		Name:     "access_token",
+		Value:    token.Jwt,
+		Path:     "/",
+		Expires:  time.Now().Add(time.Minute * 30),
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
+
+	ctx.SetCookie(newRefreshCookie)
+	ctx.SetCookie(newAccessToken)
+
+	return ctx.NoContent(http.StatusOK)
 }
 
 func (h *AuthHandler) Logout(ctx echo.Context) error {
-	cookie := &http.Cookie{
-		Name:     "jwt",
+	idParam := ctx.Param("id")
+	id, err := strconv.ParseUint(idParam, 10, 64)
+	if err != nil {
+		return echo.ErrBadRequest
+	}
+
+	err = h.serviceUser.LogoutUser(ctx.Request().Context(), id)
+	if err != nil {
+		return echo.ErrInternalServerError
+	}
+
+	newRefreshCookie := &http.Cookie{
+		Name:     "refresh",
+		Value:    "",
+		Path:     "/api/v1/auth/session",
+		Expires:  time.Now(),
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
+
+	newAccessToken := &http.Cookie{
+		Name:     "access_token",
 		Value:    "",
 		Path:     "/",
 		Expires:  time.Now(),
@@ -111,7 +158,42 @@ func (h *AuthHandler) Logout(ctx echo.Context) error {
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 	}
-	ctx.SetCookie(cookie)
+
+	ctx.SetCookie(newRefreshCookie)
+	ctx.SetCookie(newAccessToken)
+
+	return ctx.NoContent(http.StatusOK)
+}
+
+func (h *AuthHandler) UpdateSession(ctx echo.Context) error {
+	refreshCookie, err := ctx.Cookie("refresh")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "No refresh cookie provided")
+	}
+	token, err := h.serviceUser.UpdateSession(ctx.Request().Context(), &refreshCookie.Value)
+
+	newRefreshCookie := &http.Cookie{
+		Name:     "refresh",
+		Value:    token.RefreshToken,
+		Path:     "/api/v1/auth/session",
+		Expires:  time.Now().Add(time.Hour * 24 * 7),
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
+
+	newAccessToken := &http.Cookie{
+		Name:     "access_token",
+		Value:    token.Jwt,
+		Path:     "/",
+		Expires:  time.Now().Add(time.Minute * 30),
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
+
+	ctx.SetCookie(newRefreshCookie)
+	ctx.SetCookie(newAccessToken)
 
 	return ctx.NoContent(http.StatusOK)
 }

--- a/adapters/handler/user.go
+++ b/adapters/handler/user.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/labstack/echo/v4"
 	"net/http"
+	"server/adapters/tools/jwt"
 	"server/core/domain"
 	"server/core/ports"
 	"strconv"
@@ -29,6 +30,7 @@ func GetUserHandler(serviceUser ports.ServiceUser) *UserHandler {
 func (h *UserHandler) RegisterRoutes(e *echo.Group) {
 	e.GET("/users", h.GetUsers)
 	e.GET("/users/:id", h.GetUser)
+	e.GET("/user", h.GetCurrentUser)
 	//e.POST("/users", h.RegisterUser)
 }
 
@@ -96,4 +98,18 @@ func (h *UserHandler) SaveUser(ctx echo.Context) error {
 	}
 
 	return ctx.JSON(http.StatusOK, id)
+}
+
+func (h *UserHandler) GetCurrentUser(ctx echo.Context) error {
+	accessCookie, err := ctx.Cookie("access_token")
+	if err != nil {
+		return echo.ErrUnauthorized
+	}
+
+	accessToken := accessCookie.Value
+	tokenClaims, err := jwt.ParseUserClaims(accessToken)
+	if err != nil {
+		return err
+	}
+	return ctx.JSON(http.StatusOK, tokenClaims)
 }

--- a/adapters/repository/db.go
+++ b/adapters/repository/db.go
@@ -14,7 +14,7 @@ func InitDB() *gorm.DB {
 		log.New(os.Stdout, "\r\n", log.LstdFlags), // io writer
 		logger.Config{
 			SlowThreshold:             time.Second, // Slow SQL threshold
-			LogLevel:                  logger.Info, // Log level
+			LogLevel:                  logger.Warn, // Log level
 			IgnoreRecordNotFoundError: true,        // Ignore ErrRecordNotFound error for logger
 			ParameterizedQueries:      true,        // Don't include params in the SQL log
 			Colorful:                  true,        // Enable Color

--- a/adapters/repository/user.go
+++ b/adapters/repository/user.go
@@ -59,3 +59,11 @@ func (r *RepoUser) UpdateUserRefreshTokenById(ctx context.Context, id uint64, re
 
 	return result.Error
 }
+
+func (r *RepoUser) GetUserByRefreshToken(ctx context.Context, refreshToken *string) (*domain.User, error) {
+	var user *domain.User
+
+	result := r.db.Model(&domain.User{}).Where("refresh_token = ?", refreshToken).Take(&user)
+
+	return user, result.Error
+}

--- a/adapters/tools/jwt/claims.go
+++ b/adapters/tools/jwt/claims.go
@@ -1,0 +1,14 @@
+package jwt
+
+import "github.com/golang-jwt/jwt/v5"
+
+type UserClaims struct {
+	Id        uint64 `json:"id"`
+	Privilege string `json:"privilege"`
+	jwt.RegisteredClaims
+}
+
+type RefreshClaims struct {
+	Id uint64 `json:"id"`
+	jwt.RegisteredClaims
+}

--- a/adapters/tools/jwt/generator.go
+++ b/adapters/tools/jwt/generator.go
@@ -6,17 +6,6 @@ import (
 	"time"
 )
 
-type UserClaims struct {
-	Id        uint64 `json:"id"`
-	Privilege string `json:"privilege"`
-	jwt.RegisteredClaims
-}
-
-type RefreshClaims struct {
-	Id uint64 `json:"id"`
-	jwt.RegisteredClaims
-}
-
 type TokenGenerator struct {
 	User *domain.User
 }

--- a/adapters/tools/jwt/parse.go
+++ b/adapters/tools/jwt/parse.go
@@ -1,0 +1,22 @@
+package jwt
+
+import (
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/labstack/echo/v4"
+)
+
+func ParseUserClaims(accessToken string) (*UserClaims, error) {
+	token, err := jwt.ParseWithClaims(accessToken, &UserClaims{}, func(token *jwt.Token) (interface{}, error) {
+		return []byte("secret"), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	userClaims, ok := token.Claims.(*UserClaims)
+	if !ok {
+		return nil, echo.ErrBadRequest
+	}
+
+	return userClaims, nil
+}

--- a/core/ports/user.go
+++ b/core/ports/user.go
@@ -10,6 +10,8 @@ type ServiceUser interface {
 	GetUser(ctx context.Context, id uint64) (*domain.GetUser, error)
 	GetUsers(ctx context.Context) ([]*domain.GetUser, error)
 	LoginUser(ctx context.Context, user *domain.LoginUser) (*domain.Token, error)
+	LogoutUser(ctx context.Context, id uint64) error
+	UpdateSession(ctx context.Context, refreshToken *string) (*domain.Token, error)
 }
 
 type RepositoryUser interface {
@@ -18,4 +20,5 @@ type RepositoryUser interface {
 	GetUsers(ctx context.Context) ([]*domain.GetUser, error)
 	GetUserByUsername(ctx context.Context, username *string) (*domain.User, error)
 	UpdateUserRefreshTokenById(ctx context.Context, id uint64, refreshToken *string) error
+	GetUserByRefreshToken(ctx context.Context, refreshToken *string) (*domain.User, error)
 }

--- a/core/services/user.go
+++ b/core/services/user.go
@@ -99,3 +99,44 @@ func (s *ServiceUser) LoginUser(ctx context.Context, loginUser *domain.LoginUser
 
 	return token, nil
 }
+
+func (s *ServiceUser) LogoutUser(ctx context.Context, id uint64) error {
+	tokenGenerator := jwt.TokenGenerator{
+		User: &domain.User{},
+	}
+
+	token, err := tokenGenerator.Token()
+	if err != nil {
+		return err
+	}
+
+	err = s.userRepo.UpdateUserRefreshTokenById(ctx, id, &token.RefreshToken)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *ServiceUser) UpdateSession(ctx context.Context, refreshToken *string) (*domain.Token, error) {
+	user, err := s.userRepo.GetUserByRefreshToken(ctx, refreshToken)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenGenerator := jwt.TokenGenerator{
+		User: user,
+	}
+
+	token, err := tokenGenerator.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.userRepo.UpdateUserRefreshTokenById(ctx, user.ID, &token.RefreshToken)
+	if err != nil {
+		return nil, err
+	}
+
+	return token, nil
+}

--- a/tools/echo/echo.go
+++ b/tools/echo/echo.go
@@ -14,7 +14,7 @@ func GetEchoInstance() *echo.Echo {
 
 	echoInstance = echo.New()
 	echoInstance.Use(middleware.CORSWithConfig(middleware.CORSConfig{
-		AllowOrigins:                             []string{"http://localhost:5173"},
+		AllowOrigins:                             []string{"http://localhost:3000"},
 		AllowCredentials:                         true,
 		UnsafeWildcardOriginWithAllowCredentials: false,
 	}))


### PR DESCRIPTION
Now both the access token and refresh tokens are being sent as cookies. The refresh token, as to not be sent on every request, has a path set to be `/api/v1/auth/session`. 